### PR TITLE
DM-24272: Switch to lsstdm/scipipe-base as base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://issues.jenkins-ci.org/browse/JENKINS-46105
 #ARG  BASE_TAG=7-stackbase-devtoolset-6
 #FROM lsstsqre/centos:${BASE_TAG}
-ARG BASE_IMAGE=lsstsqre/centos:7-stackbase-devtoolset-8
+ARG BASE_IMAGE=lsstdm/scipipe-base:7
 FROM $BASE_IMAGE
 
 ARG LSST_SPLENV_REF


### PR DESCRIPTION
This will switch the base image to now be provided from the lsstdm/scipipe-base:7 docker tag, as built from the lsst-dm/docker-scipipe github repository (from lsst-dm/docker-scipipe#1) instead of being provided by packer-layercake built images.